### PR TITLE
googletest: init

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+
+http_archive(
+    name = "com_google_googletest",
+    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
+    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+)

--- a/bazel.mk
+++ b/bazel.mk
@@ -57,5 +57,8 @@ bazelinstall: $(BAZELPROG)
 	@cd $(BBSHOME)/bin && objcopy --add-gnu-debuglink=mbbsd.bazel.$(DATETIME).debug mbbsd.bazel.$(DATETIME)
 	@ln -sfv mbbsd.bazel.$(DATETIME) $(BBSHOME)/bin/mbbsd
 
+bazeltest:
+	CC=$(CC) $(BAZEL) test --define BBSHOME="testhome" --test_output=all ...
+
 bazelclean:
 	$(BAZEL) clean

--- a/hello_test/BUILD.bazel
+++ b/hello_test/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_test(
+    name = "hello_test",
+    size = "small",
+    srcs = [
+        "hello_test.cc",
+    ],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/hello_test/hello_test.cc
+++ b/hello_test/hello_test.cc
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, BasicAssertions) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}


### PR DESCRIPTION
We would like to use googletest as unit-test.
Have hello_test as demo of integrating googletest into WORKSPACE and bazel.mk
1. bazel.mk: instead of having BBSHOME as $(BBSHOME), we setup BBSHOME as testhome.